### PR TITLE
Add --no-sandbox option to launch chrome on unix systems

### DIFF
--- a/bin/savepdf
+++ b/bin/savepdf
@@ -12,6 +12,8 @@ const runningVivliostyleTimeout = 60 * 1000;
 
 program.arguments('<input>')
   .version(packageJSON.version)
+  .option('--no-sandbox',
+          `launch chrome without sandbox (use this option to avoid ECONNREFUSED error)`)
   .option('--preview',
           `open preview page and save PDF interactively
                             (if preview option is set, options below this line will be ignored)`)
@@ -30,8 +32,8 @@ if (program.args.length < 1) {
 }
 
 if (program.preview) {
-  preview(path.resolve(process.cwd(), program.args[0]));
+  preview(path.resolve(process.cwd(), program.args[0]), program.sandbox);
 } else {
   save(path.resolve(process.cwd(), program.args[0]),
-       path.resolve(process.cwd(), program.output), program.size, program.timeout);
+       path.resolve(process.cwd(), program.output), program.size, program.timeout, program.sandbox);
 }

--- a/lib/preview.js
+++ b/lib/preview.js
@@ -49,7 +49,12 @@ function run(input, sandbox = true) {
         });
       });
     }).catch(err => {
-      console.log('Cannot launch Chrome. Did you install it?\nviola-savepdf supports Chrome (Canary) only.');
+      if(err.code === 'ECONNREFUSED') {
+        console.log(`Cannot launch Chrome. use --no-sandbox option or open ${url} directly.`);
+      }
+      else {
+        console.log('Cannot launch Chrome. Did you install it?\nviola-savepdf supports Chrome (Canary) only.');
+      }
     });
   }).catch(err => {
     console.trace(err);

--- a/lib/preview.js
+++ b/lib/preview.js
@@ -15,7 +15,7 @@ const {
 
 module.exports = run;
 
-function run(input, size, vivliostyleTimeout) {
+function run(input, sandbox = true) {
   const stat = fs.statSync(input);
   const root = stat.isDirectory()? input : path.dirname(input);
   const index = stat.isDirectory()? 'index.html' : path.basename(input);
@@ -41,6 +41,7 @@ function run(input, size, vivliostyleTimeout) {
 
     chromeLauncher.launch({
       startingUrl: url,
+	  chromeFlags: sandbox ? [] : ['--no-sandbox']
     }).then(chrome => {
       ['SIGNIT', 'SIGTERM'].forEach(sig => {
         process.on(sig, () => {

--- a/lib/save.js
+++ b/lib/save.js
@@ -16,7 +16,7 @@ const {
 
 module.exports = run;
 
-function run(input, outputPath, size, vivliostyleTimeout) {
+function run(input, outputPath, size, vivliostyleTimeout, sandbox = true) {
   const stat = fs.statSync(input);
   const root = stat.isDirectory()? input : path.dirname(input);
   const index = stat.isDirectory()? 'index.html' : path.basename(input);
@@ -29,7 +29,7 @@ function run(input, outputPath, size, vivliostyleTimeout) {
   Promise.all([
     launchSourceServer(root),
     launchBrokerServer(),
-    launchChrome(),
+    launchChrome(sandbox),
   ]).then(([ source, broker, launcher ]) => {
     const sourceServer = source.server;
     const sourcePort = source.port;
@@ -141,13 +141,14 @@ function onPageLoad({ Page, Runtime, Emulation, outputFile, outputSize, vivliost
     });
 }
 
-function launchChrome(headless = true) {
+function launchChrome(sandbox = true, headless = true) {
   const launcherOptions = {
     port: 9222,
     chromeFlags: [
       '--window-size=1280,720',
       '--disable-gpu',
-      headless ? '--headless' : ''
+      headless ? '--headless' : '',
+      sandbox ? '' : '--no-sandbox'
     ],
   };
 

--- a/lib/save.js
+++ b/lib/save.js
@@ -160,5 +160,12 @@ function launchChrome(sandbox = true, headless = true) {
       });
     });
     return chrome;
+  }).catch(err => {
+    if(err.code === 'ECONNREFUSED') {
+      console.log(`Cannot launch headless Chrome. use --no-sandbox option.`);
+    }
+    else {
+      console.log('Cannot launch Chrome. Did you install it?\nviola-savepdf supports Chrome (Canary) only.');
+    }
   });
 }


### PR DESCRIPTION
Since the problem discussed in GoogleChrome/lighthouse#2726 and GoogleChrome/chrome-launcher#6, on the certain UNIX systems fail to launch Chrome and throw ECONNREFUSED error.

The problem is solved by adding `--no-sandbox` option to chrome-launcher, but it is a dangerous work-around and I didn't want to add this option by default.

This fix add `--no-sandbox` option to savepdf, to enable Chrome launching without Sandbox.
