### PR TITLE
add 'root' cli option

### DIFF
--- a/bin/savepdf
+++ b/bin/savepdf
@@ -20,6 +20,8 @@ program.arguments('<input>')
   .option('-o, --output <output_file>',
           `specify output file path (default output.pdf)`,
           'output.pdf')
+  .option('-r, --root <root_directory>',
+          `specify assets root path (default directory of input file)`, undefined)
   .option('-s, --size <size>',
           `output pdf size (ex: 'A4' 'JIS-B5' '182mm,257mm' '8.5in,11in')`)
   .option('-t, --timeout <time>',
@@ -35,5 +37,6 @@ if (program.preview) {
   preview(path.resolve(process.cwd(), program.args[0]), program.sandbox);
 } else {
   save(path.resolve(process.cwd(), program.args[0]),
-       path.resolve(process.cwd(), program.output), program.size, program.timeout, program.sandbox);
+       path.resolve(process.cwd(), program.output), program.size, program.timeout, program.sandbox,
+       program.root && path.resolve(process.cwd(), program.root));
 }

--- a/lib/preview.js
+++ b/lib/preview.js
@@ -13,10 +13,11 @@ const packageJSON = require('./../package.json');
 
 module.exports = run;
 
-function run(input, sandbox = true) {
+function run(input, sandbox = true, rootDir) {
   const stat = fs.statSync(input);
-  const root = stat.isDirectory()? input : path.dirname(input);
-  const index = stat.isDirectory()? 'index.html' : path.basename(input);
+  const root = rootDir || (stat.isDirectory() ? input : path.dirname(input));
+  const indexFile = stat.isDirectory()? path.resolve(input, 'index.html') : input;
+  const index = path.relative(root, indexFile);
 
   launchSourceAndBrokerServer(root).then(([ source, broker ]) => {
     const sourcePort = source.port;

--- a/lib/save.js
+++ b/lib/save.js
@@ -17,7 +17,8 @@ module.exports = run;
 function run(input, outputPath, size, vivliostyleTimeout, sandbox = true, rootDir) {
   const stat = fs.statSync(input);
   const root = rootDir || (stat.isDirectory() ? input : path.dirname(input));
-  const index = stat.isDirectory()? 'index.html' : path.basename(input);
+  const indexFile = stat.isDirectory()? path.resolve(input, 'index.html') : input;
+  const index = path.relative(root, indexFile);
 
   const outputFile = fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()
     ? path.resolve(outputPath, 'output.pdf')

--- a/lib/save.js
+++ b/lib/save.js
@@ -14,9 +14,9 @@ const {
 
 module.exports = run;
 
-function run(input, outputPath, size, vivliostyleTimeout, sandbox = true) {
+function run(input, outputPath, size, vivliostyleTimeout, sandbox = true, rootDir) {
   const stat = fs.statSync(input);
-  const root = stat.isDirectory()? input : path.dirname(input);
+  const root = rootDir || (stat.isDirectory() ? input : path.dirname(input));
   const index = stat.isDirectory()? 'index.html' : path.basename(input);
 
   const outputFile = fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()


### PR DESCRIPTION
### problem

- some 'static site generator' uses an absolute path.
   - for example, `/assets/example.css` as the CSS path
- there is not necessarily html in the `/` path.
   - for example, `/book/index.html`
- can not reference `/assets/example.css` from`/book/index.html` now

### solution

- add the `--root` option
   - specify the root of the document manually if needed
